### PR TITLE
Updated versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
   },
   "require": {
     "php": ">=5.4",
-    "johnpbloch/wordpress": "4.5.*",
+    "johnpbloch/wordpress": "4.4.*",
     "composer/installers": "~1.0",
     "jjgrainger/wp-custom-post-type-class": "~1.4",
     "advanced-custom-fields/advanced-custom-fields-pro": "*"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "repositories": [
     {
       "type": "composer",
-      "url": "http://wpackagist.org"
+      "url": "https://wpackagist.org"
     },
     {
       "type": "vcs",
@@ -36,7 +36,7 @@
       "type": "package",
       "package": {
         "name": "advanced-custom-fields/advanced-custom-fields-pro",
-        "version": "5.3.2.2",
+        "version": "5.3.7",
         "type": "wordpress-plugin",
         "dist": {
           "type": "zip",
@@ -52,7 +52,7 @@
   },
   "require": {
     "php": ">=5.4",
-    "johnpbloch/wordpress": "4.3.*",
+    "johnpbloch/wordpress": "4.5.*",
     "composer/installers": "~1.0",
     "jjgrainger/wp-custom-post-type-class": "~1.4",
     "advanced-custom-fields/advanced-custom-fields-pro": "*"


### PR DESCRIPTION
- Latest version of WP (4.5)
- Latest version of ACF (5.3.7)
- Switched to https:// protocol for WPackagist
